### PR TITLE
저장소를 데이터베이스로 하는 repository 구현체를 만들어 파일을 저장소로 쓸 때와 차이점을 알아본다

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,16 @@
 plugins {
     kotlin("jvm") version "1.9.25"
     kotlin("plugin.spring") version "1.9.25"
+    kotlin("plugin.jpa") version "1.9.25"
+    kotlin("plugin.allopen") version "1.9.25"
     id("org.springframework.boot") version "3.5.0"
     id("io.spring.dependency-management") version "1.1.7"
+}
+
+allOpen {
+    annotation("javax.persistence.Entity")
+    annotation("javax.persistence.MappedSuperclass")
+    annotation("javax.persistence.Embeddable")
 }
 
 group = "nmh"
@@ -22,8 +30,11 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+    runtimeOnly("com.h2database:h2")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,9 +8,9 @@ plugins {
 }
 
 allOpen {
-    annotation("javax.persistence.Entity")
-    annotation("javax.persistence.MappedSuperclass")
-    annotation("javax.persistence.Embeddable")
+    annotation("jakarta.persistence.Entity")
+    annotation("jakarta.persistence.MappedSuperclass")
+    annotation("jakarta.persistence.Embeddable")
 }
 
 group = "nmh"

--- a/src/main/kotlin/nmh/prac/application/user/UserServiceImpl.kt
+++ b/src/main/kotlin/nmh/prac/application/user/UserServiceImpl.kt
@@ -1,11 +1,12 @@
 package nmh.prac.application.user
 
+import jakarta.transaction.Transactional
 import nmh.prac.domain.user.User
 import nmh.prac.domain.user.UserModel
 import org.springframework.stereotype.Component
 
 @Component
-class UserFileService(
+class UserServiceImpl(
     private val userRepository: UserRepository
 ) : UserService {
     override fun register(name: String, age: Int): UserModel {
@@ -30,6 +31,7 @@ class UserFileService(
         return userRepository.save(updatedUser)
     }
 
+    @Transactional
     override fun somethingWithException(id: Long, name: String, age: Int) {
         userRepository.findById(id) ?: throw NoSuchElementException("ID가 ${id}인 유저가 없습니다.")
         userRepository.save(User(id = id, name = "김성공", age = 50))

--- a/src/main/kotlin/nmh/prac/infrastructure/user/UserJpaEntity.kt
+++ b/src/main/kotlin/nmh/prac/infrastructure/user/UserJpaEntity.kt
@@ -1,0 +1,13 @@
+package nmh.prac.infrastructure.user
+
+import jakarta.persistence.*
+import nmh.prac.domain.user.UserModel
+
+@Entity
+@Table(name = "users")
+class UserJpaEntity(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    override var id: Long = 0,
+    override val name: String,
+    override val age: Int
+) : UserModel

--- a/src/main/kotlin/nmh/prac/infrastructure/user/UserJpaRepository.kt
+++ b/src/main/kotlin/nmh/prac/infrastructure/user/UserJpaRepository.kt
@@ -1,0 +1,48 @@
+package nmh.prac.infrastructure.user
+
+import nmh.prac.application.user.UserRepository
+import nmh.prac.domain.user.User
+import nmh.prac.domain.user.UserModel
+import org.springframework.context.annotation.Primary
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+
+interface UserJpaRepository : JpaRepository<UserJpaEntity, Long>
+
+@Primary
+@Component
+class UserRepositoryImpl(
+    private val userJpaRepository: UserJpaRepository
+) : UserRepository {
+    override fun save(user: UserModel): UserModel {
+        val entity = UserJpaEntity(
+            id = user.id,
+            name = user.name,
+            age = user.age
+        )
+        return userJpaRepository.save(entity).toModel()
+    }
+
+    override fun findAll(): List<UserModel> {
+        return userJpaRepository.findAll().map { it.toModel() }
+    }
+
+    override fun findById(id: Long): UserModel? {
+        return userJpaRepository.findByIdOrNull(id)?.toModel()
+    }
+
+    override fun deleteAll() {
+        userJpaRepository.deleteAll()
+    }
+
+    override fun deleteById(id: Long) {
+        userJpaRepository.deleteById(id)
+    }
+
+    private fun UserJpaEntity.toModel() = User(
+        id = this.id,
+        name = this.name,
+        age = this.age,
+    )
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=deliberate-develop

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:~/test
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true

--- a/src/test/kotlin/nmh/prac/application/user/UserFileServiceTest.kt
+++ b/src/test/kotlin/nmh/prac/application/user/UserFileServiceTest.kt
@@ -1,19 +1,20 @@
 package nmh.prac.application.user
 
 import nmh.prac.domain.user.User
-import nmh.prac.infrastructure.user.UserFileRepository
-import org.assertj.core.api.BDDAssertions
+import org.assertj.core.api.BDDAssertions.then
+import org.assertj.core.api.BDDAssertions.thenThrownBy
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Description
 import org.springframework.test.context.TestConstructor
 
 @SpringBootTest
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 class UserFileServiceTest(
-    private val userFileRepository: UserFileRepository
+    private val userRepository: UserRepository
 ) {
 
     @Autowired
@@ -21,7 +22,7 @@ class UserFileServiceTest(
 
     @AfterEach
     fun tearDown() {
-        userFileRepository.deleteAll()
+        userRepository.deleteAll()
     }
 
     @Test
@@ -33,7 +34,7 @@ class UserFileServiceTest(
         )
         // when
         // then
-        BDDAssertions.then(userService.register(user.name, user.age))
+        then(userService.register(user.name, user.age))
             .extracting("name", "age")
             .containsExactly("나민혁", 26)
 
@@ -43,15 +44,15 @@ class UserFileServiceTest(
     fun `사용자를 조회 할 수 있다`() {
         // given
         val user = User(name = "나민혁", age = 26)
-        val savedUser = userFileRepository.save(user)
+        val savedUser = userRepository.save(user)
         // when
         val foundUser = userService.getById(savedUser.id)
         // then
-        BDDAssertions.then(foundUser)
+        then(foundUser)
             .extracting("name", "age")
             .containsExactly("나민혁", 26)
 
-        BDDAssertions.then(userFileRepository.findById(savedUser.id))
+        then(userRepository.findById(savedUser.id))
             .extracting("name", "age")
             .containsExactly("나민혁", 26)
 
@@ -63,21 +64,21 @@ class UserFileServiceTest(
         val user1 = User(name = "나민혁", age = 26)
         val user2 = User(name = "나나나", age = 53)
 
-        userFileRepository.save(user1)
-        userFileRepository.save(user2)
+        userRepository.save(user1)
+        userRepository.save(user2)
         // when
         val users = userService.getAll()
         // then
-        BDDAssertions.then(users)
+        then(users)
             .isNotEmpty
             .hasSize(2)
             .anySatisfy {
-                BDDAssertions.then(it.name).isEqualTo("나민혁")
-                BDDAssertions.then(it.age).isEqualTo(26)
+                then(it.name).isEqualTo("나민혁")
+                then(it.age).isEqualTo(26)
             }
             .anySatisfy {
-                BDDAssertions.then(it.name).isEqualTo("나나나")
-                BDDAssertions.then(it.age).isEqualTo(53)
+                then(it.name).isEqualTo("나나나")
+                then(it.age).isEqualTo(53)
             }
     }
 
@@ -85,11 +86,11 @@ class UserFileServiceTest(
     fun `사용자를 id를 통해 삭제 할 수 있다`() {
         // given
         val user = User(name = "나민혁", age = 26)
-        val savedUser = userFileRepository.save(user)
+        val savedUser = userRepository.save(user)
         // when
         userService.deleteById(savedUser.id)
         // then
-        BDDAssertions.then(userFileRepository.findById(savedUser.id))
+        then(userRepository.findById(savedUser.id))
             .isNull()
     }
 
@@ -97,51 +98,54 @@ class UserFileServiceTest(
     fun `사용자 정보를 변경 할 수 있다`() {
         // given
         val user = User(name = "나민혁", age = 26)
-        val savedUser = userFileRepository.save(user)
+        val savedUser = userRepository.save(user)
         // when
         val updatedUser = userService.updateById(savedUser.id, "나나나", 53)
         // then
-        BDDAssertions.then(updatedUser)
+        then(updatedUser)
             .extracting("name", "age")
             .containsExactly("나나나", 53)
 
-        BDDAssertions.then(userFileRepository.findById(savedUser.id))
+        then(userRepository.findById(savedUser.id))
             .extracting("name", "age")
             .containsExactly("나나나", 53)
 
     }
 
+    @Description("파일을 저장소로 사용 할 경우 원자성이 지켜지지 않을 수 있다")
+    @Disabled("파일이 아니기 때문에 테스트 제외")
     @Test
-    fun `파일을 저장소로 사용 할 경우 원자성이 지켜지지 않을 수 있다`() {
+    fun `저장이 아토믹한지 확인한다`() {
         // given
         val user1 = User(name = "나민혁", age = 26)
         val user2 = User(name = "나나나", age = 53)
-        val savedUser = userFileRepository.save(user1)
-        userFileRepository.save(user2)
+        val savedUser = userRepository.save(user1)
+        userRepository.save(user2)
         // when
         // then
-        BDDAssertions.thenThrownBy { userService.somethingWithException(savedUser.id, "김스트", 11) }
+        thenThrownBy { userService.somethingWithException(savedUser.id, "김스트", 11) }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessage("무언가 잘못되었기 때문에 예외를 발생시킵니다")
 
         // 아토믹한 파일 저장소를 사용하지 않는 경우, 예외 발생 후에도 이전 상태가 유지되지 않을 수 있다.
-        BDDAssertions.then(userFileRepository.findById(savedUser.id))
+        then(userRepository.findById(savedUser.id))
             .extracting("name", "age")
             .containsExactly("김성공", 50)
     }
 
-    @Disabled("파일을 저장소로 사용 할 경우 원자성이 지켜지지 않을 수 있다 원자성이 보장되는 경우에만 아래 테스트가 통과한다")
+    @Description("파일을 저장소로 사용 할 경우 트랜잭션을 구현하지 않으면 원자성이 지켜지지 않는다")
     @Test
-    fun `파일을 저장소로 사용 할 경우 트랜잭션을 구현하지 않으면 원자성이 지켜지지 않는다`() {
+    fun `저장이 아토믹한 연산인지 확인한다`() {
         // given
         val user1 = User(name = "나민혁", age = 26)
         val user2 = User(name = "나나나", age = 53)
-        val savedUser = userFileRepository.save(user1)
-        userFileRepository.save(user2)
+        val savedUser = userRepository.save(user1)
+        userRepository.save(user2)
         // when
-        userService.somethingWithException(savedUser.id, "김스트", 11)
+        thenThrownBy{ userService.somethingWithException(savedUser.id, "김스트", 11) }
+            .isInstanceOf(IllegalArgumentException::class.java)
         // then
-        BDDAssertions.then(userFileRepository.findById(savedUser.id))
+        then(userRepository.findById(savedUser.id))
             .extracting("name", "age")
             .containsExactly("나민혁", 26)
     }

--- a/src/test/kotlin/nmh/prac/e2e/UserControllerE2ETest.kt
+++ b/src/test/kotlin/nmh/prac/e2e/UserControllerE2ETest.kt
@@ -1,6 +1,8 @@
 package nmh.prac.e2e
 
 import nmh.prac.api.user.request.UserRegisterRequest
+import nmh.prac.infrastructure.user.UserJpaRepository
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.TestConstructor
@@ -9,8 +11,14 @@ import org.springframework.test.web.reactive.server.WebTestClient
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 class UserControllerE2ETest(
-    private val webTestClient: WebTestClient
+    private val webTestClient: WebTestClient,
+    private val userRepository: UserJpaRepository
 ) {
+
+    @AfterEach
+    fun tearDown() {
+        userRepository.deleteAllInBatch()
+    }
 
     @Test
     fun `새로운 사용자를 등록한다`() {

--- a/src/test/kotlin/nmh/prac/infrastructure/user/UserRepositoryImplTest.kt
+++ b/src/test/kotlin/nmh/prac/infrastructure/user/UserRepositoryImplTest.kt
@@ -1,0 +1,67 @@
+package nmh.prac.infrastructure.user
+
+import org.assertj.core.api.BDDAssertions.then
+import org.assertj.core.api.BDDAssertions.thenThrownBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Description
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+
+@SpringBootTest
+class UserRepositoryImplTest {
+
+    @Autowired
+    private lateinit var userRepository: UserRepositoryImpl
+
+    @Autowired
+    private lateinit var userJpaRepository: UserJpaRepository
+
+    @AfterEach
+    fun tearDown() {
+        userJpaRepository.deleteAllInBatch()
+    }
+
+    @Test
+    fun `사용자 요청이 동시에 일어날 경우를 확인한다`() {
+        // given
+        val threadCount = 20
+        val executorService = Executors.newFixedThreadPool(10)
+        val latch = CountDownLatch(threadCount)
+
+        // when
+        for (i in 0 until threadCount) {
+            executorService.execute {
+                try {
+                    userRepository.save(UserJpaEntity(name = "나민혁$i", age = 26 + i))
+                } finally {
+                    latch.countDown()
+                }
+            }
+        }
+
+        latch.await()
+        // then
+        then(userJpaRepository.findAll()).hasSize(20)
+    }
+
+    @Description("해당 테스트는 무시가 된다. 이유를 알 수 없음")
+    @Test
+    fun `한번에 조회하는 데이터가 너무 많으면 OOM이 일어난다`() {
+        // given
+        val largeDataCount = 1_000_000_000
+        val users = (1..largeDataCount).map { 
+            UserJpaEntity(name = "User$it", age = it % 100 + 1)
+        }
+        userJpaRepository.saveAll(users)
+
+        // when
+        // then
+        thenThrownBy {
+            userRepository.findAll()
+        }.isInstanceOf(OutOfMemoryError::class.java)
+    }
+}

--- a/src/test/kotlin/nmh/prac/infrastructure/user/UserRepositoryImplTest.kt
+++ b/src/test/kotlin/nmh/prac/infrastructure/user/UserRepositoryImplTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Description
+import org.springframework.test.context.jdbc.Sql
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 
@@ -48,17 +49,12 @@ class UserRepositoryImplTest {
         then(userJpaRepository.findAll()).hasSize(20)
     }
 
-    @Description("해당 테스트는 무시가 된다. 셋업 데이터를 준비하면서 문제가 발생해서 해당 테스트가 무시되는것 같음")
-    @Disabled("OOM이 발생하는 테스트로, 실제로는 실행되지 않습니다.")
+    @Description("SQL로 데이터를 삽입하고 조회 할 때 OOM이 발생하는지 확인하지만 실제로 데이터를 삽입할 때 부터 OOM이 발생 할 수 있다.")
+    @Disabled("이 테스트는 OOM을 유발할 수 있으므로 주석 처리합니다.")
+    @Sql("/datas/bulk-user.sql")
     @Test
     fun `한번에 조회하는 데이터가 너무 많으면 OOM이 일어난다`() {
         // given
-        val largeDataCount = 1_000_000_000
-        val users = (1..largeDataCount).map {
-            UserJpaEntity(name = "User$it", age = it % 100 + 1)
-        }
-        userJpaRepository.saveAll(users)
-
         // when
         // then
         thenThrownBy {

--- a/src/test/kotlin/nmh/prac/infrastructure/user/UserRepositoryImplTest.kt
+++ b/src/test/kotlin/nmh/prac/infrastructure/user/UserRepositoryImplTest.kt
@@ -3,9 +3,9 @@ package nmh.prac.infrastructure.user
 import org.assertj.core.api.BDDAssertions.then
 import org.assertj.core.api.BDDAssertions.thenThrownBy
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Description
 import java.util.concurrent.CountDownLatch
@@ -48,12 +48,13 @@ class UserRepositoryImplTest {
         then(userJpaRepository.findAll()).hasSize(20)
     }
 
-    @Description("해당 테스트는 무시가 된다. 이유를 알 수 없음")
+    @Description("해당 테스트는 무시가 된다. 셋업 데이터를 준비하면서 문제가 발생해서 해당 테스트가 무시되는것 같음")
+    @Disabled("OOM이 발생하는 테스트로, 실제로는 실행되지 않습니다.")
     @Test
     fun `한번에 조회하는 데이터가 너무 많으면 OOM이 일어난다`() {
         // given
         val largeDataCount = 1_000_000_000
-        val users = (1..largeDataCount).map { 
+        val users = (1..largeDataCount).map {
             UserJpaEntity(name = "User$it", age = it % 100 + 1)
         }
         userJpaRepository.saveAll(users)

--- a/src/test/kotlin/nmh/prac/learning/JpaInterfaceImplementationCreationTest.kt
+++ b/src/test/kotlin/nmh/prac/learning/JpaInterfaceImplementationCreationTest.kt
@@ -1,0 +1,39 @@
+package nmh.prac.learning
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jdk.jfr.Description
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContext
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.support.SimpleJpaRepository
+import org.springframework.stereotype.Component
+import java.lang.reflect.Proxy
+
+@SpringBootTest
+class JpaInterfaceImplementationCreationTest {
+
+    @Autowired
+    private lateinit var repository: SampleRepository
+
+    @Description("디버거를 통해서 SimpleJpaRepository의 메서드를 호출 하는지 확인 할 수 있다")
+    @Disabled("해당 테스트는 단순히 JpaRepository 인터페이스의 구현체가 생성되는지 확인하기 위한 테스트입니다.")
+    @Test
+    fun name() {
+        repository.save(SampleEntity(name = "실험용"))
+    }
+}
+
+@Entity
+class SampleEntity(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+    val name: String,
+)
+
+interface SampleRepository: JpaRepository<SampleEntity, Long>

--- a/src/test/resources/datas/bulk-user.sql
+++ b/src/test/resources/datas/bulk-user.sql
@@ -1,0 +1,5 @@
+INSERT INTO users (name, age)
+SELECT
+    CONCAT('User', x) as name,
+    (x % 100) + 1 as age
+FROM system_range(1, 100000) as t(x);


### PR DESCRIPTION
- #2 

# 파일 시스템에서 기대하지 못했던 부분을 충족시켜주는 부분
- 트랜잭션을 지원하지 않는다
- 아토믹한 연산이 일어나 예외가 발생하면 롤백이 된다.
- 동시성문제를 `@Syncrhonize`를 이용해 잡아야 한다. 하지만 JpaRepository를 이용하면 사용하지 않고 동시성이 잡힌다. (근데 이건 더 공부해봐야 할듯)
- 파일을 저장소로 사용할 때는 무슨 행동을 하든 모든 파일을 읽어야했기 때문에 OOM이 일어나지만 DB의 용량이 얼마가 되었든 특정 레코드만 읽을 때 OOM이 일어나지않는다.
  - 현재 OOM을 일으키는 테스트를 실행시키면 ignored된다 해당 이슈는 무엇인지 확인해볼 것

---
# 추가로 확인해보면 좋을 것
- 스레드를 두개 사용하여 트랜잭션사이에 끼어드는 연산을 파일도, DB도 해보면 좋을 것 같다.
- JPA를 사용하며 연관관계에 대하여 OOM이 터지는지 확인하기(Lazy하게 들고오는지 확인?)
  - 예를 들자면 이런 상황 User를 조회하는데 Post가 100만개가 있을 때 어떤 상황인지 확인
- 이외에 DB만의 특별한 상황이 있을지 떠올려보기 예: select for update, 트랜잭션 격리 등

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for JPA-based persistence and database interaction, including a new user entity and repository implementation.
  * Introduced application monitoring capabilities.
  * Added configuration for an in-memory H2 database with automatic schema management.

* **Bug Fixes**
  * Improved naming and consistency in user service and repository classes.

* **Tests**
  * Added new tests for JPA repository concurrency and memory handling.
  * Enhanced existing tests for clarity and consistency with repository usage.
  * Added tests to verify JPA interface implementation and end-to-end user controller cleanup.

* **Chores**
  * Updated build configuration and dependencies for JPA and database support.
  * Migrated configuration properties to YAML format and removed obsolete settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->